### PR TITLE
Update template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 ## Site Setup
 
-The quickest way to get a Docsify site up and running is with GitHub Pages:  
+### Static Webserver
+Upload these template files to any static web server. The file `.nojekyll` is only required if hosting the site on GitHub Pages and otherwise can be removed.
+
+### GitHub Pages
+
+#### Hosting Site
+
+To host this template on GitHub Pages do the following:  
 
 1. Log into GitHub if you have not done so already
 2. Tap the **Use this template** button in the upper-right of this GitHub Repository and choose **Create a new repository**
@@ -12,11 +19,12 @@ The quickest way to get a Docsify site up and running is with GitHub Pages:
 4. Once your new Repostitory is created go to **Settings**, then select **Pages** from the left-hand sidebar, and under **Branch** choose **main** and then tap the **Save** button
 5. Wait a minute or two and refresh the same **Pages** page - once your site is ready a message will be displayed at the top of the screen along with a site link and a **Visit site** button
 
-Alternatively, upload the files to any static web server. Or run `npx serve .` (Node.js users) or `python -m http.server 8000` (Python users) in the repo to serve run locally.
+#### Editing Content
 
-## Editing Content
+How about editing the content of your new Docsify site on GitHub Pages? All you need to do is edit a source Markdown page (for example,  **README.md**) by viewing that page and tapping the **Pencil Icon**, then saving any changes by tapping the green **Commit changes...** button. In just a few moments the Docsify site will be automatically updated to reflect those changes.
 
-How about editing the content of your new Docsify site? All you need to do is edit a source Markdown page (for example,  **README.md**) by viewing that page and tapping the **Pencil Icon**, then saving any changes by tapping the green **Commit changes...** button. In just a few moments the Docsify site will be automatically updated to reflect those changes!
+### Viewing Locally 
+Run `npx serve .` (Node.js users) or `python -m http.server 8000` (Python users) in the repo folder to serve run locally.
 
 ## Docsify Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# Simple Docsify Template
+# Docsify Template
 
-> A simple Docsify template that requires no build steps.
+> A simple [Docsify](https://github.com/docsifyjs/docsify/) template for creating Markdown-based documentation sites, with no build process required.
 
-Just upload the files to any static web server. Or run `npx serve .` (Node.js users) or `python -m http.server 8000` (Python users) in the repo to serve run locally.
+## Site Setup
+
+The quickest way to get a Docsify site up and running is with GitHub Pages:  
+
+1. Log into GitHub if you have not done so already
+2. Tap the **Use this template** button in the upper-right of this GitHub Repository and choose **Create a new repository**
+3. Enter a name for your new Repository and then tap the **Create repository** button
+4. Once your new Repostitory is created go to **Settings**, then select **Pages** from the left-hand sidebar, and under **Branch** choose **main** and then tap the **Save** button
+5. Wait a minute or two and refresh the same **Pages** page - once your site is ready a message will be displayed at the top of the screen along with a site link and a **Visit site** button
+
+Alternatively, upload the files to any static web server. Or run `npx serve .` (Node.js users) or `python -m http.server 8000` (Python users) in the repo to serve run locally.
+
+## Editing Content
+
+How about editing the content of your new Docsify site? All you need to do is edit a source Markdown page (for example,  **README.md**) by viewing that page and tapping the **Pencil Icon**, then saving any changes by tapping the green **Commit changes...** button. In just a few moments the Docsify site will be automatically updated to reflect those changes!
+
+## Docsify Documentation
+
+To learn more about using Docsify, visit https://docsify.js.org.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To host this template on GitHub Pages do the following:
 
 #### Editing Content
 
-How about editing the content of your new Docsify site on GitHub Pages? All you need to do is edit a source Markdown page (for example,  **README.md**) by viewing that page and tapping the **Pencil Icon**, then saving any changes by tapping the green **Commit changes...** button. In just a few moments the Docsify site will be automatically updated to reflect those changes.
+How about editing the content of your new Docsify site on GitHub Pages? View the Markdown page you want to edit (for example, **README.md**) and tap the **Pencil Icon**, then save any changes by tapping the green **Commit changes...** button. In just a few moments the Docsify site will be automatically updated to reflect those changes.
 
 ### Viewing Locally 
 Run `npx serve .` (Node.js users) or `python -m http.server 8000` (Python users) in the repo folder to serve run locally.

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,2 +1,2 @@
-- [ReadMe](README)
+- [Read Me](README)
 - [Second Page](second-page)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,2 @@
+- [README](README)
+- [Second Page](second-page)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,2 +1,2 @@
 - [Read Me](README)
-- [Second Page](second-page)
+- [Example Second Page](second-page)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,2 +1,2 @@
-- [README](README)
+- [ReadMe](README)
 - [Second Page](second-page)

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <title>Docsify</title>
 
   <!-- Default Theme -->
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/buble.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
 
 </head>
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,14 @@
     window.$docsify = {
       name: 'Simple Docsify Template',
 
+      // Sidebar Configuration
+      auto2top: true,
+      loadSidebar: true,
+      maxLevel: 0,
+      // Set subMaxLevel to 0 to remove automatic display of page table of contents (TOC) in Sidebar
+      subMaxLevel: 3,
+
+      // Search Plugin Configuration
       search: {
         placeholder: 'Type to search',
         noData: 'No matches found.',

--- a/index.html
+++ b/index.html
@@ -1,22 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <meta charset="UTF-8">
-  <title>Document</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Description">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1, minimum-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
+  <meta name="description" content="">
+  <title>Docsify</title>
+
+  <!-- Default Theme -->
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/buble.css">
+
 </head>
+
 <body>
   <div id="app"></div>
+
   <script>
+    // Docsify Configuration
     window.$docsify = {
-      name: '',
-      repo: ''
-    }
+      name: 'Simple Docsify Template',
+
+      search: {
+        placeholder: 'Type to search',
+        noData: 'No matches found.',
+        // Headline depth, 1 - 6
+        depth: 2,
+      }
+    };
   </script>
-  <!-- Docsify v4 -->
-  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+
+  <!-- Required -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+
+  <!-- Recommended -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+
 </body>
 </html>

--- a/second-page.md
+++ b/second-page.md
@@ -1,0 +1,3 @@
+# Second Page
+
+This is an example second page that will appear in the Docsify Sidebar.

--- a/second-page.md
+++ b/second-page.md
@@ -1,3 +1,3 @@
-# Second Page
+# Example Second Page
 
 This is an example second page that will appear in the Docsify Sidebar.


### PR DESCRIPTION
To help more users get going quickly with Docsify I thought it would be helpful to do the following:

1. Add a few more instructions in the ReadMe (without images for now, as the GitHub UI seems to change more frequently these days)
2. Include how to use GitHub Pages with Docsify (fastest way out there)
3. Do a bit of cleanup on the index.html file and add a few default plugins

Much more could be done, but the purpose of this template seems to be a "simple" template which needs minimal updating so that it the approach I took.

I've also made a 'partner' template using Docsify-Themeable, which you can be viewed here if of interest: https://github.com/paulhibbitts/docsify-themeable-template

Thanks for considering the PR.
Paul
ps - if this PR is accepted then I have a follow-up PR for the main ReadMe to better match this revised template etc.